### PR TITLE
Added Prettier with eslint-config-prettier & initial config

### DIFF
--- a/src/frontend/.prettierrc
+++ b/src/frontend/.prettierrc
@@ -1,0 +1,9 @@
+﻿{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/src/frontend/eslint.config.mjs
+++ b/src/frontend/eslint.config.mjs
@@ -2,28 +2,31 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+    baseDirectory: __dirname,
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+    ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
   
-  eslintPluginUnicorn.configs.recommended,
+    eslintPluginUnicorn.configs.recommended,
   
-  {
-    ignores: [
-      "node_modules/**",
-      ".next/**",
-      "out/**",
-      "build/**",
-      "next-env.d.ts",
-    ],
-  },
+    {
+        ignores: [
+            "node_modules/**",
+            ".next/**",
+            "out/**",
+            "build/**",
+            "next-env.d.ts",
+        ],
+
+        rules: {
+            semi: "error",
+        }
+    },
 ];  
 
 export default eslintConfig;

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9.35.0",
         "eslint-config-next": "15.5.2",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-unicorn": "^61.0.2",
@@ -2965,6 +2966,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -21,6 +21,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9.35.0",
     "eslint-config-next": "15.5.2",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-unicorn": "^61.0.2",

--- a/src/frontend/src/app/layout.tsx
+++ b/src/frontend/src/app/layout.tsx
@@ -2,9 +2,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-// Unused variable should be flagged
-const unusedVariable = 42;
-
 const geistSans = Geist({
     variable: "--font-geist-sans",
     subsets: ["latin"],
@@ -36,8 +33,3 @@ export default function RootLayout({
         </html>
     );
 }
-
-// Missing semicolon and console statement should also be flagged
-console.log("Debuuug output")
-
-const foo_bar = 1;


### PR DESCRIPTION
Added the Prettier tool into the Front-End application. ESLint is setup to use `eslint-config-prettier` to ensure no conflicting rules between the two tool, and the initial `.prettierrc` config is setup for some standard React Typescript standard styling guidelines.