### PR TITLE
Added Husky pre-commit

### DIFF
--- a/.github/workflows/_deploy-azure-static-web-app.yaml
+++ b/.github/workflows/_deploy-azure-static-web-app.yaml
@@ -56,3 +56,4 @@ jobs:
               app_location: ${{ inputs.app_location }}
               output_location: ".next"
               skip_app_build: true
+              deployment_environment: ${{ inputs.target_env }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+for project in src/*; do
+  if [ -f "$project/package.json" ]; then
+    echo "▶️ Node project detected in $project"
+    npm run pre-commit --prefix "$project" || exit 1
+  elif [ -f "$project/project.csproj" ]; then
+    echo "▶️ .NET project detected in $project"
+  else
+    echo "ℹ️ Skipping $project (no recognized config)"
+  fi
+done

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "move-the-chains",
+  "version": "1.0.0",
+  "description": "The plan for this project is to result in an NFL-related Web App/Website consisting of two main features-sets:",
+  "main": "index.js",
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "@movethechains/portal",
   "version": "0.1.0",
   "private": true,
   "engines": {
@@ -9,7 +9,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "pre-commit": "npx eslint src/ --fix --max-warnings 0"
   },
   "dependencies": {
     "eslint-plugin-prettier": "^5.5.4",


### PR DESCRIPTION
Setup the Monorepo as a node project such that Husky can run a pre-commit. 

Thus-far the pre-commit performs just Linting/Formatting on the Portal project, but can be extended and perform pre-commit steps on other projects in the future. 